### PR TITLE
Cache the node path lookup

### DIFF
--- a/run-node.sh
+++ b/run-node.sh
@@ -1,10 +1,48 @@
 #!/bin/bash
-eval $(/usr/libexec/path_helper -s)
-eval "$($SHELL -i -l -c 'echo -e "\n"PATH=\"$PATH:\$PATH\""\n"' 2>/dev/null | grep "^PATH=")"
-export PATH
+if [[ -z "$alfred_workflow_cache" ]]; then
+	echo "This script must be called from Alfred, \$alfred_workflow_cache is missing"
+	exit 1
+fi
 
-if command -v node >/dev/null 2>&1; then
-	node "$1" "$2"
+if [[ ! -d "$alfred_workflow_cache" ]]; then
+    mkdir -p "$alfred_workflow_cache"
+fi
+
+PATH_CACHE="$alfred_workflow_cache"/node_path
+
+get_user_path() {
+    eval $(/usr/libexec/path_helper -s)
+    echo "$($SHELL -i -l -c 'echo -e "\n"PATH=\"$PATH:\$PATH\""\n"' 2>/dev/null | grep "^PATH=")" > "$PATH_CACHE"
+}
+
+set_path() {
+    if [[ -f "$PATH_CACHE" ]]; then
+        . "$PATH_CACHE"
+    else
+        get_user_path
+        . "$PATH_CACHE"
+    fi
+
+    export PATH
+}
+
+has_node() {
+    command -v node >/dev/null 2>&1
+}
+
+# Check if we have node, otherwise inherit path from user shell
+if ! has_node; then
+    set_path
+
+    # Retry by deleting old path cache
+    if ! has_node; then
+        rm "$PATH_CACHE"
+        set_path
+    fi
+fi
+
+if has_node; then
+	node "$@"
 else
 	echo $'{"items":[{"title": "Couldn\'t find the `node` binary", "subtitle": "Symlink it to `/usr/local/bin`"}]}'
 fi


### PR DESCRIPTION
Avoid starting up a complete login shell on every execution, if at any point `node` can no longer be found, the cache is invalidated and we make a new attempt at finding it.

* All script parameters are passed to node, not just `$1` and `$2`
* Stores cache in `.path_cache` (inside workflow directory)
* Does nothing special if `node` is found
* Tries to use cache (for path) if it exists
* Refresh cache if `node` is not found

This PR originated from: https://github.com/sindresorhus/alfred-emoj/pull/5