### PR TITLE
add `maxAge` option for `alfy.cache` - fixes #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const Conf = require('conf');
 const hookStd = require('hook-std');
 const loudRejection = require('loud-rejection');
 const cleanStack = require('clean-stack');
+const CacheConf = require('./lib/cache-conf');
 
 // prevent caching of this module so module.parent is always accurate
 delete require.cache[__filename];
@@ -96,7 +97,7 @@ alfy.config = new Conf({
 	cwd: alfy.alfred.data
 });
 
-alfy.cache = new Conf({
+alfy.cache = new CacheConf({
 	configName: 'cache',
 	cwd: alfy.alfred.cache
 });

--- a/lib/cache-conf.js
+++ b/lib/cache-conf.js
@@ -1,0 +1,42 @@
+'use strict';
+const Conf = require('conf');
+
+const isExpired = item => item && item.timestamp && item.timestamp < Date.now();
+
+class CacheConf extends Conf {
+
+	get(key) {
+		const ret = super.get(key);
+
+		if (isExpired(ret)) {
+			super.delete(key);
+			return;
+		}
+
+		return ret.data;
+	}
+
+	set(key, val, opts) {
+		opts = opts || {};
+
+		super.set(key, {
+			timestamp: opts.maxAge && Date.now() + opts.maxAge,
+			data: val
+		});
+	}
+
+	has(key) {
+		if (!super.has(key)) {
+			return false;
+		}
+
+		if (isExpired(super.get(key))) {
+			super.delete(key);
+			return false;
+		}
+
+		return true;
+	}
+}
+
+module.exports = CacheConf;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "files": [
     "index.js",
-    "run-node.sh"
+    "run-node.sh",
+    "lib"
   ],
   "keywords": [
     "alfred",
@@ -43,6 +44,7 @@
   },
   "devDependencies": {
     "ava": "*",
+    "delay": "^1.3.1",
     "xo": "*"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ Type: `Object`
 
 Persist cache data.
 
-Exports a [`conf` instance](https://github.com/sindresorhus/conf#instance) with the correct cache path set.
+Exports a modified [`conf` instance](https://github.com/sindresorhus/conf#instance) with the correct cache path set.
 
 Example:
 
@@ -152,6 +152,22 @@ alfy.cache.set('unicorn', '🦄');
 
 alfy.cache.get('unicorn');
 //=> '🦄'
+```
+
+##### maxAge
+
+The `set` method of this instance accepts an optional third argument where you can provide a `maxAge` option. `maxAge` is
+the number of milliseconds the value is valid in the cache.
+
+Example:
+
+```js
+alfy.cache.set('foo', 'bar', {maxAge: 5000});
+
+await delay(5000);
+
+alfy.cache.get('foo');
+// undefined
 ```
 
 #### debug

--- a/readme.md
+++ b/readme.md
@@ -162,12 +162,18 @@ the number of milliseconds the value is valid in the cache.
 Example:
 
 ```js
+const delay = require('delay');
+
 alfy.cache.set('foo', 'bar', {maxAge: 5000});
 
+alfy.cache.get('foo');
+//=> 'bar'
+
+// Wait 5 seconds
 await delay(5000);
 
 alfy.cache.get('foo');
-// undefined
+//=> undefined
 ```
 
 #### debug

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,34 @@
+import test from 'ava';
+import delay from 'delay';
+
+process.env.AVA = true;
+const m = require('..');
+
+test('no cache', t => {
+	m.cache.set('foo', 'bar');
+
+	t.is(m.cache.get('foo'), 'bar');
+	t.true(m.cache.has('foo'));
+});
+
+test('maxAge option', t => {
+	m.cache.set('hello', {hello: 'world'}, {maxAge: 300000});
+
+	const age = m.cache.store.hello.timestamp - Date.now();
+
+	t.true(age <= 300000 && age >= 299000);
+	t.true(m.cache.has('hello'));
+	t.deepEqual(m.cache.get('hello'), {hello: 'world'});
+});
+
+test('expired data', async t => {
+	m.cache.set('expire', {foo: 'bar'}, {maxAge: 5000});
+
+	t.true(m.cache.has('expire'));
+	t.deepEqual(m.cache.get('expire'), {foo: 'bar'});
+
+	await delay(5000);
+
+	t.false(m.cache.has('expire'));
+	t.falsy(m.cache.store.expire);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import hookStd from 'hook-std';
 
 process.env.AVA = true;
-const m = require('./');
+const m = require('../');
 
 test('default', t => {
 	t.false(m.debug);


### PR DESCRIPTION
- Extended the `Conf` class and override the `set`, `get` and `has` methods
- Added tests for the cache
- Added documentation regarding the `maxAge` option

As described in #3, not sure if we should do it with the `CacheConf` object here, add that option to `Conf` or create an external `CacheConf` module to handle this. Will to do either one of those :).

Feel free to suggest improvements of the code or docs.