### PR TITLE
add init script - fixes #26

### DIFF
--- a/init.js
+++ b/init.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+'use strict';
+const execa = require('execa');
+const npmRunPath = require('npm-run-path');
+
+const env = npmRunPath.env({cwd: __dirname});
+
+execa('alfred-link', {env}).catch(err => {
+	console.error(err);
+	process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     }
   ],
   "bin": {
-    "run-node": "run-node.sh"
+    "run-node": "run-node.sh",
+    "alfy-init": "init.js"
   },
   "engines": {
     "node": ">=4"
@@ -27,6 +28,7 @@
   },
   "files": [
     "index.js",
+    "init.js",
     "run-node.sh"
   ],
   "keywords": [
@@ -42,13 +44,16 @@
     "osx"
   ],
   "dependencies": {
+    "alfred-link": "^0.1.4",
     "cache-conf": "^0.2.0",
     "clean-stack": "^1.0.0",
     "conf": "^0.11.0",
     "dot-prop": "^4.0.0",
+    "execa": "^0.5.0",
     "got": "^6.3.0",
     "hook-std": "^0.2.0",
-    "loud-rejection": "^1.6.0"
+    "loud-rejection": "^1.6.0",
+    "npm-run-path": "^2.0.2"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@
 - Easy input↔output.
 - Config and cache handling built-in.
 - Fetching remote files with optional caching.
+- Publish your workflow to npm.
 - [Finds the `node` binary.](run-node.sh)
 - Presents uncaught exceptions and unhandled Promise rejections to the user.<br>
   *No need to manually `.catch()` top-level promises.*
@@ -74,9 +75,7 @@ Some example usage in the wild: [`alfred-npms`](https://github.com/sindresorhus/
 
 ## Publish to npm
 
-Instead of publishing your packages to [Packal](http://www.packal.org), you can also publish them to [npm](https://npmjs.org). This way, your packages are only one simple `npm install` command away.
-
-Add [alfred-link](https://github.com/samverschueren/alfred-link) as dependency to your package and add it as `postinstall` script.
+By adding `alfy-init` as `postinstall` script, you can publish your package to [npm](https://npmjs.org) instead of to [Packal](http://www.packal.org). This way, your packages are only one simple `npm install` command away.
 
 ```json
 {
@@ -89,7 +88,7 @@ Add [alfred-link](https://github.com/samverschueren/alfred-link) as dependency t
     "url": "sindresorhus.com"
   },
   "scripts": {
-    "postinstall": "alfred-link"
+    "postinstall": "alfy-init"
   },
   "dependencies": {
     "alfy": "*",


### PR DESCRIPTION
It's very hard to test if this works because of the way `npm link` behaves. It does not behave the same as `npm install`.

I took `./node_modules/.bin/alfred-link` as the path to execute. I think this should be fine (although not sure). So if you have any feedback on that? Apparently `npm@2.x` also puts the binaries directly in the `.bin` directory at the root.

Also if you want to call the script differently, be my guest :).

- `alfy-init`
- `alfy` (might be confusing)
- `alfy-install`