### PR TITLE
Clarify error message for missing `$alfred_workflow_cache`

### DIFF
--- a/run-node.sh
+++ b/run-node.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z "$alfred_workflow_cache" ]]; then
-	echo "This script must be called from Alfred, \$alfred_workflow_cache is missing"
+	echo "This script must be called from Alfred, \$alfred_workflow_cache is missing. Make sure a bundleId is set."
 	exit 1
 fi
 


### PR DESCRIPTION
The `$alfred_workflow_cache` env variable is blank if your new workflow is missing a `Bundle Id`.
In this case, the error message is fairly unintuitive to determine what exactly is wrong, hopefully this will prevent anyone else from ever getting caught up like I did :)

![screen shot 2016-10-13 at 11 23 55 am](https://cloud.githubusercontent.com/assets/1612134/19355238/ae4ce2b2-9137-11e6-9585-eafbe398f6ab.png)
