### PR TITLE
:arrow_up: cache-conf@0.3.0 - fixes #34

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "alfred-link": "^0.1.4",
     "alfred-notifier": "^0.2.0",
-    "cache-conf": "^0.2.0",
+    "cache-conf": "^0.3.0",
     "clean-stack": "^1.0.0",
     "conf": "^0.11.0",
     "dot-prop": "^4.0.0",

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 ## Highlights
 
 - Easy input↔output.
-- Config and cache handling built-in.
+- Config and [cache](#caching) handling built-in.
 - Fetching remote files with optional caching.
 - Publish your workflow to npm.
 - Automatic [update notifications](#update-notifications).
@@ -78,6 +78,13 @@ Some example usage in the wild: [`alfred-npms`](https://github.com/sindresorhus/
 Alfy uses [alfred-notifier](https://github.com/SamVerschueren/alfred-notifier) in the background to show a notification when an update for your workflow is available.
 
 <img src="media/screenshot-update.png" width="694">
+
+
+## Caching
+
+Alfy offers the possibility of caching data, either with the [fetch](#fetchurl-options) or directly through the [cache](#cache) object.
+
+An important thing to note is that the cached data gets invalidated automatically when you update your workflow. This offers the flexibility for developers to change the structure of the cached data between workflows without having to worry about older structures.
 
 
 ## Publish to npm

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ Alfy uses [alfred-notifier](https://github.com/SamVerschueren/alfred-notifier) i
 
 Alfy offers the possibility of caching data, either with the [fetch](#fetchurl-options) or directly through the [cache](#cache) object.
 
-An important thing to note is that the cached data gets invalidated automatically when you update your workflow. This offers the flexibility for developers to change the structure of the cached data between workflows without having to worry about older structures.
+An important thing to note is that the cached data gets invalidated automatically when you update your workflow. This offers the flexibility for developers to change the structure of the cached data between workflows without having to worry about invalid older data.
 
 
 ## Publish to npm

--- a/test/_utils.js
+++ b/test/_utils.js
@@ -3,10 +3,12 @@
 const path = require('path');
 const tempfile = require('tempfile');
 
-exports.alfy = () => {
+exports.alfy = options => {
+	options = options || {};
+
 	delete require.cache[path.resolve(__dirname, '../index.js')];
 
-	process.env.alfred_workflow_cache = tempfile();
-	process.env.alfred_workflow_version = '1.0.0';
+	process.env.alfred_workflow_cache = options.cache || tempfile();
+	process.env.alfred_workflow_version = options.version || '1.0.0';
 	return require('..');
 };

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,8 +1,7 @@
 import test from 'ava';
 import delay from 'delay';
+import tempfile from 'tempfile';
 import {alfy} from './_utils';
-
-process.env.AVA = true;
 
 test('no cache', t => {
 	const m = alfy();
@@ -35,4 +34,17 @@ test('expired data', async t => {
 	t.false(m.cache.has('expire'));
 	t.falsy(m.cache.get('expire'));
 	t.falsy(m.cache.store.expire);
+});
+
+test('versioned data', async t => {
+	const cache = tempfile();
+
+	const m = alfy({cache, version: '1.0.0'});
+	m.cache.set('foo', 'bar');
+
+	const m2 = alfy({cache, version: '1.0.0'});
+	t.is(m2.cache.get('foo'), 'bar');
+
+	const m3 = alfy({cache, version: '1.0.1'});
+	t.falsy(m3.cache.get('foo'));
 });

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,6 @@ import test from 'ava';
 import hookStd from 'hook-std';
 import {alfy} from './_utils';
 
-process.env.AVA = true;
 const m = alfy();
 
 m.input = 'Unicorn';


### PR DESCRIPTION
I extracted the versioning to `cache-conf` which means we could remove that logic from the `fetch` method and it also works automatically for `alfy.cache`.

I also removed the `process.env.AVA` check because my `_utils.js` file imports `alfy` and attaches a `tempfile` as environment variable. This allows more flexibility for testing.