### PR TITLE
add cleanup script

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+'use strict';
+const execa = require('execa');
+const npmRunPath = require('npm-run-path');
+
+const env = npmRunPath.env({cwd: __dirname});
+
+execa('alfred-unlink', {env}).catch(err => {
+	console.error(err);
+	process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "bin": {
     "run-node": "run-node.sh",
-    "alfy-init": "init.js"
+    "alfy-init": "init.js",
+    "alfy-cleanup": "cleanup.js"
   },
   "engines": {
     "node": ">=4"
@@ -29,6 +30,7 @@
   "files": [
     "index.js",
     "init.js",
+    "cleanup.js",
     "run-node.sh",
     "lib"
   ],
@@ -45,7 +47,7 @@
     "osx"
   ],
   "dependencies": {
-    "alfred-link": "^0.1.4",
+    "alfred-link": "^0.2.0",
     "alfred-notifier": "^0.2.0",
     "cache-conf": "^0.3.0",
     "clean-stack": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ An important thing to note is that the cached data gets invalidated automaticall
 
 ## Publish to npm
 
-By adding `alfy-init` as `postinstall` script, you can publish your package to [npm](https://npmjs.org) instead of to [Packal](http://www.packal.org). This way, your packages are only one simple `npm install` command away.
+By adding `alfy-init` as `postinstall` and `alfy-cleanup` as `preuninstall` script, you can publish your package to [npm](https://npmjs.org) instead of to [Packal](http://www.packal.org). This way, your packages are only one simple `npm install` command away.
 
 ```json
 {
@@ -102,7 +102,8 @@ By adding `alfy-init` as `postinstall` script, you can publish your package to [
     "url": "sindresorhus.com"
   },
   "scripts": {
-    "postinstall": "alfy-init"
+    "postinstall": "alfy-init",
+    "preuninstall": "alfy-cleanup"
   },
   "dependencies": {
     "alfy": "*"


### PR DESCRIPTION
After adding all the unlink logic to `alfred-link`, time to expose it directly in `alfy`.

I added a `cleanup.js` script that is being exposed as the `alfy-cleanup`. This should be added as `preuninstall` script and will perform the following actions.

- Remove the symlink in the workflows directory
- Remove the workflow data in the data directory
- Remove the cached data in the cache directory

Other possible names for the cleanup script could be
- `alfy-gc`
- `alfy-collect`
- `alfy-destroy`
- `alfy-uninstall`
- ...

`alfy-cleanup` was just the first thing that came in my mind. Wouldn't mind change that name for something better.