### PR TITLE
Add alfred-keycode workflow to Users section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -502,6 +502,7 @@ Non-synced local preferences are stored within `Alfred.alfredpreferences` under 
 - [alfred-hl](https://github.com/importre/alfred-hl) - Syntax highlight code in the clipboard
 - [alfred-workflow-docs-elastic](https://github.com/spinscale/alfred-workflow-elastic-docs) - Search the Elastic.co documentation
 - [alfredinary](https://github.com/urre/alfredinary) - Capture screenshots and upload to Cloudinary
+- [alfred-keycode](https://github.com/radibit/alfred-keycode) - Search for JavaScript keycode
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -502,7 +502,7 @@ Non-synced local preferences are stored within `Alfred.alfredpreferences` under 
 - [alfred-hl](https://github.com/importre/alfred-hl) - Syntax highlight code in the clipboard
 - [alfred-workflow-docs-elastic](https://github.com/spinscale/alfred-workflow-elastic-docs) - Search the Elastic.co documentation
 - [alfredinary](https://github.com/urre/alfredinary) - Capture screenshots and upload to Cloudinary
-- [alfred-keycode](https://github.com/radibit/alfred-keycode) - Search for JavaScript keycode
+- [alfred-keycode](https://github.com/radibit/alfred-keycode) - Get JavaScript keycodes
 
 
 ## Related


### PR DESCRIPTION
Hey, this PR is adding [alfred-keycode](https://github.com/radibit/alfred-keycode) to the Users section in the readme.