### PR TITLE
Add `alfred-yandex-translate` to Users section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -542,6 +542,7 @@ Non-synced local preferences are stored within `Alfred.alfredpreferences` under 
 - [alfred-packagist](https://github.com/vinkla/alfred-packagist) - Search for PHP packages with Packagist
 - [alfred-vpn](https://github.com/stve/alfred-vpn) - Connect/disconnect from VPNs
 - [alfred-clap](https://github.com/jacc/alfred-clap) - 👏🏻 Clap 👏🏻 stuff 👏🏻 out 👏🏻 in 👏🏻 Alfred! 👏🏻
+- [alfred-yandex-translate](https://github.com/mkalygin/alfred-yandex-translate) - Translate words and text with Yandex Translate
 
 
 ## Related


### PR DESCRIPTION
Alfy is great for building Alfred workflows! Definitely will use it again, thanks!

This workflow uses [Yandex Translate](https://translate.yandex.com/) and shows a list of translations. You can translate words and texts. Please see repo's [readme](https://github.com/mkalygin/alfred-yandex-translate) for more info. I've developed it for my daily usage.