### PR TITLE
Add alfred-show-network-info added to Users section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -545,7 +545,7 @@ Non-synced local preferences are stored within `Alfred.alfredpreferences` under 
 - [alfred-yandex-translate](https://github.com/mkalygin/alfred-yandex-translate) - Translate words and text with Yandex Translate
 - [alfred-now](https://github.com/lucaperret/alfred-now) - Use [Now](https://zeit.co/now) commands within Alfred to access deployments and aliases
 - [alfred-chuck-norris-jokes](https://github.com/jeppestaerk/alfred-chuck-norris-jokes) - Get Chuck Norris jokes
-- [alfred-show-network-info](https://github.com/jeppestaerk/alfred-show-network-info) - Get your network information in Alfred
+- [alfred-show-network-info](https://github.com/jeppestaerk/alfred-show-network-info) - Get your network info
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -545,6 +545,7 @@ Non-synced local preferences are stored within `Alfred.alfredpreferences` under 
 - [alfred-yandex-translate](https://github.com/mkalygin/alfred-yandex-translate) - Translate words and text with Yandex Translate
 - [alfred-now](https://github.com/lucaperret/alfred-now) - Use [Now](https://zeit.co/now) commands within Alfred to access deployments and aliases
 - [alfred-chuck-norris-jokes](https://github.com/jeppestaerk/alfred-chuck-norris-jokes) - Get Chuck Norris jokes
+- [alfred-show-network-info](https://github.com/jeppestaerk/alfred-show-network-info) - Get your network information in Alfred
 
 
 ## Related


### PR DESCRIPTION
Alfred 3 workflow for getting IPv4 or IPv6 local, public and gateway addresses.