### PR TITLE
Add support for user-configurable workflows

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const loudRejection = require('loud-rejection');
 const cleanStack = require('clean-stack');
 const dotProp = require('dot-prop');
 const CacheConf = require('cache-conf');
+const AlfredConfig = require('alfred-config');
 const updateNotification = require('./lib/update-notification');
 
 const alfy = module.exports;
@@ -96,6 +97,10 @@ ${process.platform} ${os.release()}
 };
 
 alfy.config = new Conf({
+	cwd: alfy.alfred.data
+});
+
+alfy.userConfig = new AlfredConfig({
 	cwd: alfy.alfred.data
 });
 

--- a/index.js
+++ b/index.js
@@ -100,9 +100,7 @@ alfy.config = new Conf({
 	cwd: alfy.alfred.data
 });
 
-alfy.userConfig = new AlfredConfig({
-	cwd: alfy.alfred.data
-});
+alfy.userConfig = new AlfredConfig();
 
 alfy.cache = new CacheConf({
 	configName: 'cache',

--- a/init.js
+++ b/init.js
@@ -8,6 +8,11 @@ const execa = require('execa');
 			preferLocal: true,
 			localDir: __dirname
 		});
+
+		await execa('alfred-config', {
+			preferLocal: true,
+			localDir: __dirname
+		});
 	} catch (error) {
 		console.error(error);
 		process.exit(1);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"mac"
 	],
 	"dependencies": {
+		"alfred-config": "^0.2.1",
 		"alfred-link": "^0.3.1",
 		"alfred-notifier": "^0.2.0",
 		"cache-conf": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"mac"
 	],
 	"dependencies": {
-		"alfred-config": "^0.2.1",
+		"alfred-config": "^0.2.2",
 		"alfred-link": "^0.3.1",
 		"alfred-notifier": "^0.2.0",
 		"cache-conf": "^0.6.0",

--- a/readme.md
+++ b/readme.md
@@ -393,6 +393,19 @@ alfy.config.get('unicorn');
 //=> '🦄'
 ```
 
+#### userConfig
+
+Type: `object`
+
+If the workflow supports user configuration, it will export a readable [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) with the user workflow configuration.
+
+Example:
+
+```js
+alfy.userConfig.get('apiKey');
+//=> '16811cad1b8547478b3e53eae2e0f083'
+```
+
 #### cache
 
 Type: `object`

--- a/readme.md
+++ b/readme.md
@@ -395,9 +395,11 @@ alfy.config.get('unicorn');
 
 #### userConfig
 
-Type: `object`
+Type: `Map`
 
-If the workflow supports user configuration, it will export a readable [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) with the user workflow configuration.
+Exports a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) with the user workflow configuration. A workflow configuration allows your users to provide configuration information for the workflow. For instance, if you are developing a GitHub workflow, you could let your users provide their own API tokens.
+
+See [`alfred-config`](https://github.com/SamVerschueren/alfred-config#workflow-configuration) for more details.
 
 Example:
 

--- a/test/_utils.js
+++ b/test/_utils.js
@@ -6,6 +6,7 @@ const tempfile = require('tempfile');
 exports.alfy = (options = {}) => {
 	delete require.cache[path.resolve(__dirname, '../index.js')];
 
+	process.env.alfred_workflow_data = options.data || tempfile();
 	process.env.alfred_workflow_cache = options.cache || tempfile();
 	process.env.alfred_workflow_version = options.version || '1.0.0';
 	return require('..');

--- a/test/fixtures/config/user-config.json
+++ b/test/fixtures/config/user-config.json
@@ -1,0 +1,7 @@
+{
+	// 🦄 Unicorns 🦄
+	"unicorn": "🦄",
+
+	// 🌈 Rainbows 🌈
+	"rainbow": "🌈"
+}

--- a/test/user-config.js
+++ b/test/user-config.js
@@ -10,5 +10,5 @@ test('read user config', t => {
 	t.is(alfy.userConfig.size, 2);
 	t.is(alfy.userConfig.get('unicorn'), '🦄');
 	t.is(alfy.userConfig.get('rainbow'), '🌈');
-	t.is(alfy.userConfig.has('foo'), false);
+	t.false(alfy.userConfig.has('foo'));
 });

--- a/test/user-config.js
+++ b/test/user-config.js
@@ -1,0 +1,14 @@
+import path from 'path';
+import test from 'ava';
+import {alfy as createAlfy} from './_utils';
+
+test('read user config', t => {
+	const alfy = createAlfy({
+		data: path.join(__dirname, 'fixtures/config')
+	});
+
+	t.is(alfy.userConfig.size, 2);
+	t.is(alfy.userConfig.get('unicorn'), '🦄');
+	t.is(alfy.userConfig.get('rainbow'), '🌈');
+	t.is(alfy.userConfig.has('foo'), false);
+});


### PR DESCRIPTION
This PR fixes #36 by adding support for user configurable workspaces. It's as simple as creating a `config.json` file in your workflow package and it will open it with the default text editor when installing the workflow.