### PR TITLE
Fix alfy-init freezing with some editors (e.g. vim)

### DIFF
--- a/init.js
+++ b/init.js
@@ -11,7 +11,8 @@ const execa = require('execa');
 
 		await execa('alfred-config', {
 			preferLocal: true,
-			localDir: __dirname
+			localDir: __dirname,
+			stdio: 'inherit'
 		});
 	} catch (error) {
 		console.error(error);


### PR DESCRIPTION
Hey folks!

When you have a `config.json` file in your project, during installation `alfy-init` is gonna call [alfred-config](https://github.com/SamVerschueren/alfred-config) to copy this file and open on the default editor.

There's a problem when you have a terminal-based editor such as `vim` set, `postinstall` script is gonna freeze waiting for the editor to close, but it's never visible for the user in the first place, so you'll be stuck.

This PR tries to fix this issue by inheriting `stdio`.

If you wanna try to reproduce this, simply create a `config.json` file in your alfy project, run `EDITOR=vim npm install` and you should be stuck as well.