### PR TITLE
Support non-json `fetch` responses again

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,13 +137,13 @@ alfy.fetch = async (url, options) => {
 		return cachedResponse;
 	}
 
-	// Set responseType to 'text' if options.json === false or default to Json
 	if ('json' in options && options.json === false) {
 		delete options.json;
 		options.responseType = 'text';
 	} else {
 		options.responseType = 'json';
 	}
+
 	options.resolveBodyOnly = true;
 
 	let response;

--- a/index.js
+++ b/index.js
@@ -137,9 +137,14 @@ alfy.fetch = async (url, options) => {
 		return cachedResponse;
 	}
 
+	const json = ('json' in options && options.json === false) ? false : true; // eslint-disable-line no-unneeded-ternary
+	if (!json) {
+		delete options.json;
+	}
+
 	let response;
 	try {
-		response = await got(url, options).json();
+		response = json ? await got(url, options).json() : (await got(url, options)).body;
 	} catch (error) {
 		if (cachedResponse) {
 			return cachedResponse;

--- a/index.js
+++ b/index.js
@@ -116,16 +116,6 @@ alfy.fetch = async (url, options) => {
 		...options,
 	};
 
-	// Set responseType to 'text' if options.json === false or default to Json
-	if ('json' in options && options.json === false) {
-		delete options.json;
-		options.responseType = 'text';
-		options.resolveBodyOnly = true;
-	} else {
-		options.responseType = 'json';
-		options.resolveBodyOnly = true;
-	}
-
 	// Deprecated, but left for backwards-compatibility.
 	if (options.query) {
 		options.searchParams = options.query;
@@ -146,6 +136,15 @@ alfy.fetch = async (url, options) => {
 	if (cachedResponse && !alfy.cache.isExpired(key)) {
 		return cachedResponse;
 	}
+
+	// Set responseType to 'text' if options.json === false or default to Json
+	if ('json' in options && options.json === false) {
+		delete options.json;
+		options.responseType = 'text';
+	} else {
+		options.responseType = 'json';
+	}
+	options.resolveBodyOnly = true;
 
 	let response;
 	try {

--- a/index.js
+++ b/index.js
@@ -137,14 +137,14 @@ alfy.fetch = async (url, options) => {
 		return cachedResponse;
 	}
 
-	const json = ('json' in options && options.json === false) ? false : true; // eslint-disable-line no-unneeded-ternary
-	if (!json) {
+	const rawBodyRequested = 'json' in options && options.json === false;
+	if (rawBodyRequested) {
 		delete options.json;
 	}
 
 	let response;
 	try {
-		response = json ? await got(url, options).json() : (await got(url, options)).body;
+		response = rawBodyRequested ? (await got(url, options)).body : await got(url, options).json();
 	} catch (error) {
 		if (cachedResponse) {
 			return cachedResponse;

--- a/index.js
+++ b/index.js
@@ -116,6 +116,16 @@ alfy.fetch = async (url, options) => {
 		...options,
 	};
 
+	// Set responseType to 'text' if options.json === false or default to Json
+	if ('json' in options && options.json === false) {
+		delete options.json;
+		options.responseType = 'text';
+		options.resolveBodyOnly = true;
+	} else {
+		options.responseType = 'json';
+		options.resolveBodyOnly = true;
+	}
+
 	// Deprecated, but left for backwards-compatibility.
 	if (options.query) {
 		options.searchParams = options.query;
@@ -137,14 +147,9 @@ alfy.fetch = async (url, options) => {
 		return cachedResponse;
 	}
 
-	const rawBodyRequested = 'json' in options && options.json === false;
-	if (rawBodyRequested) {
-		delete options.json;
-	}
-
 	let response;
 	try {
-		response = rawBodyRequested ? (await got(url, options)).body : await got(url, options).json();
+		response = await got(url, options);
 	} catch (error) {
 		if (cachedResponse) {
 			return cachedResponse;

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -13,6 +13,7 @@ test.before(() => {
 	nock(URL).get('/cache-key?unicorn=rainbow').reply(200, {unicorn: 'rainbow'});
 	nock(URL).get('/cache-version').once().reply(200, {foo: 'bar'});
 	nock(URL).get('/cache-version').twice().reply(200, {unicorn: 'rainbow'});
+	nock(URL).get('/string-response').once().reply(200, 'unicorn is rainbow');
 });
 
 test('no cache', async t => {
@@ -73,4 +74,9 @@ test('invalid version', async t => {
 	/// const alfy3 = createAlfy({cache, version: '1.0.1'});
 	// t.deepEqual(await alfy3.fetch(`${URL}/cache-version`, {maxAge: 5000}), {unicorn: 'rainbow'});
 	// t.deepEqual(alfy.cache.store['https://foo.bar/cache-version{"maxAge":5000}'].data, {unicorn: 'rainbow'});
+});
+
+test('non-json response', async t => {
+	const alfy = createAlfy();
+	t.is(await alfy.fetch(`${URL}/string-response`, {json: false}), 'unicorn is rainbow');
 });

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -76,7 +76,7 @@ test('invalid version', async t => {
 	// t.deepEqual(alfy.cache.store['https://foo.bar/cache-version{"maxAge":5000}'].data, {unicorn: 'rainbow'});
 });
 
-test('non-json response', async t => {
+test('non-JSON response', async t => {
 	const alfy = createAlfy();
 	t.is(await alfy.fetch(`${URL}/string-response`, {json: false}), 'unicorn is rainbow');
 });


### PR DESCRIPTION
As I noted in #152, turning off `json: parsing` doesn't work ever since https://github.com/sindresorhus/alfy/commit/56aed04cff57d49635a8182af8aa696c70852bfa

This puts it back, while (hopefully) not breaking json requests - it activates only if the option `json` is set _exactly_ to `false

Fixes #152