### PR TITLE
Add alfred-pwgen to users section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -639,6 +639,7 @@ Non-synced local preferences are stored within `Alfred.alfredpreferences` under 
 - [alfred-amphetamine](https://github.com/demartini/alfred-amphetamine) - Start and end sessions quickly in the Amphetamine app
 - [alfred-ids](https://github.com/rizowski/alfred-ids) - Generate various types of IDs.
 - [alfred-awesome-stars](https://github.com/jopemachine/alfred-awesome-stars) - Search starred GitHub repos through awesome-stars.
+- [alfred-pwgen](https://github.com/olssonm/alfred-password-generator) - Generate random and secure passwords.
 
 ## Related
 


### PR DESCRIPTION
Added reference to [alfred-pwgen](https://github.com/olssonm/alfred-password-generator) in the Users-section. A simple workflow to quickly get a random password.

Huge thanks for yet another great package!
