### PR TITLE
Add alfred-color-converter to Users section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -641,6 +641,7 @@ Non-synced local preferences are stored within `Alfred.alfredpreferences` under 
 - [alfred-awesome-stars](https://github.com/jopemachine/alfred-awesome-stars) - Search starred GitHub repos through awesome-stars.
 - [alfred-pwgen](https://github.com/olssonm/alfred-password-generator) - Generate random and secure passwords.
 - [alfred-bear](https://github.com/jmeischner/alfred-bear) - Use dynamic templates with the Bear app.
+- [alfred-color-converter](https://github.com/toFrankie/alfred-color-converter) - Convert colors between RGB and HEX.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -641,7 +641,7 @@ Non-synced local preferences are stored within `Alfred.alfredpreferences` under 
 - [alfred-awesome-stars](https://github.com/jopemachine/alfred-awesome-stars) - Search starred GitHub repos through awesome-stars.
 - [alfred-pwgen](https://github.com/olssonm/alfred-password-generator) - Generate random and secure passwords.
 - [alfred-bear](https://github.com/jmeischner/alfred-bear) - Use dynamic templates with the Bear app.
-- [alfred-color-converter](https://github.com/toFrankie/alfred-color-converter) - Convert colors between RGB and HEX.
+- [alfred-color-converter](https://github.com/toFrankie/alfred-color-converter) - Convert colors between RGB and Hex.
 
 ## Related
 


### PR DESCRIPTION
[alfy](https://github.com/sindresorhus/alfy) is a very convenient tool, and based on it, a color conversion tool called [alfred-color-converter](https://github.com/toFrankie/alfred-color-converter) is made.