### PR TITLE
Make `resolveBodyOnly` overridable + plus docs updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,7 @@ alfy.cache = new CacheConf({
 
 alfy.fetch = async (url, options) => {
 	options = {
+		resolveBodyOnly: true,
 		...options,
 	};
 
@@ -149,8 +150,6 @@ alfy.fetch = async (url, options) => {
 	} else {
 		options.responseType = 'json';
 	}
-
-	options.resolveBodyOnly = true;
 
 	let response;
 	try {

--- a/readme.md
+++ b/readme.md
@@ -398,7 +398,7 @@ await alfy.fetch('https://api.foo.com', {
 
 Type: `Function`
 
-Transform the response before it gets cached.
+Transform the response body before it gets cached.
 
 ```js
 import alfy from 'alfy';
@@ -411,7 +411,7 @@ await alfy.fetch('https://api.foo.com', {
 })
 ```
 
-Transform the full response.
+Transform the response.
 
 ```js
 import alfy from 'alfy';

--- a/readme.md
+++ b/readme.md
@@ -371,18 +371,27 @@ Number of milliseconds this request should be cached.
 Type: `boolean`\
 Default: `true`
 
-Determine whether body only or full response will be resolved.
+Whether to resolve with only body or a full response.
 
 ```js
 import alfy from 'alfy';
 
-await alfy.fetch('https://api.foo.com')
-//=> {"foo": "bar"}
+await alfy.fetch('https://api.foo.com');
+//=> {foo: 'bar'}
 
 await alfy.fetch('https://api.foo.com', {
-	resolveBodyOnly:	false 
-})
-//=> {"body": {"foo": "bar"}, "headers": {"content-type": "application/json"}}
+	resolveBodyOnly: false 
+});
+/*
+{
+	body: {
+		foo: 'bar'
+	},
+	headers: {
+		'content-type': 'application/json'
+	}
+}
+*/
 ```
 
 ###### transform

--- a/readme.md
+++ b/readme.md
@@ -366,6 +366,25 @@ Type: `number`
 
 Number of milliseconds this request should be cached.
 
+###### resolveBodyOnly
+
+Type: `boolean`\
+Default: `true`
+
+Determine whether body only or full response will be resolved.
+
+```js
+import alfy from 'alfy';
+
+await alfy.fetch('https://api.foo.com')
+//=> {"foo": "bar"}
+
+await alfy.fetch('https://api.foo.com', {
+	resolveBodyOnly:	false 
+})
+//=> {"body": {"foo": "bar"}, "headers": {"content-type": "application/json"}}
+```
+
 ###### transform
 
 Type: `Function`
@@ -379,6 +398,20 @@ await alfy.fetch('https://api.foo.com', {
 	transform: body => {
 		body.foo = 'bar';
 		return body;
+	}
+})
+```
+
+Transform the full response.
+
+```js
+import alfy from 'alfy';
+
+await alfy.fetch('https://api.foo.com', {
+	resolveBodyOnly: false,
+	transform: response => {
+		response.body.foo = 'bar';
+		return response;
 	}
 })
 ```

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -80,7 +80,7 @@ test('cache key', async t => {
 	const alfy = createAlfy();
 
 	t.deepEqual(await alfy.fetch(`${URL}/cache-key`, {searchParams: {unicorn: 'rainbow'}, maxAge: 5000}), {unicorn: 'rainbow'});
-	t.truthy(alfy.cache.store['https://foo.bar/cache-key{"searchParams":{"unicorn":"rainbow"},"maxAge":5000}']);
+	t.truthy(alfy.cache.store['https://foo.bar/cache-key{"resolveBodyOnly":true,"searchParams":{"unicorn":"rainbow"},"maxAge":5000}']);
 });
 
 test('invalid version', async t => {
@@ -89,7 +89,7 @@ test('invalid version', async t => {
 	const alfy = createAlfy({cache, version: '1.0.0'});
 	t.deepEqual(await alfy.fetch(`${URL}/cache-version`, {maxAge: 5000}), {foo: 'bar'});
 	t.deepEqual(await alfy.fetch(`${URL}/cache-version`, {maxAge: 5000}), {foo: 'bar'});
-	t.deepEqual(alfy.cache.store['https://foo.bar/cache-version{"maxAge":5000}'].data, {foo: 'bar'});
+	t.deepEqual(alfy.cache.store['https://foo.bar/cache-version{"resolveBodyOnly":true,"maxAge":5000}'].data, {foo: 'bar'});
 
 	const alfy2 = createAlfy({cache, version: '1.0.0'});
 	t.deepEqual(await alfy2.fetch(`${URL}/cache-version`, {maxAge: 5000}), {foo: 'bar'});

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -14,6 +14,7 @@ test.before(() => {
 	nock(URL).get('/cache-version').once().reply(200, {foo: 'bar'});
 	nock(URL).get('/cache-version').twice().reply(200, {unicorn: 'rainbow'});
 	nock(URL).get('/string-response').once().reply(200, 'unicorn is rainbow');
+	nock(URL).get('/dont-resolve-body').once().reply(200, {foo: 'bar'}, {link: 'foobar'});
 });
 
 test('no cache', async t => {
@@ -79,4 +80,11 @@ test('invalid version', async t => {
 test('non-JSON response', async t => {
 	const alfy = createAlfy();
 	t.is(await alfy.fetch(`${URL}/string-response`, {json: false}), 'unicorn is rainbow');
+});
+
+test('disable resolveBodyOnly', async t => {
+	const alfy = createAlfy();
+	const result = await alfy.fetch(`${URL}/dont-resolve-body`, {resolveBodyOnly: false});
+	t.deepEqual(result.headers, {'content-type': 'application/json', link: 'foobar'});
+	t.deepEqual(result.body, {foo: 'bar'});
 });


### PR DESCRIPTION
### Description
This is the extension of #161 PR  by @gksander and adds examples to the documentation and some tests updates

### Original PR

Closes #161

---------------------
### What? 
This PR allows the resolveBodyOnly fetch option to be overridden from alfy.fetch's options arg.

### Why?
Sometimes you need access to response headers. For example, when using GitHub's REST API, the pagination details for paginated endpoints are returned in response headers (instead of response body).